### PR TITLE
Add all operations about files

### DIFF
--- a/src/aqfs.rs
+++ b/src/aqfs.rs
@@ -52,7 +52,7 @@ pub struct FileMeta {
     pub mtime: DateTime<Utc>,
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait File {
     fn meta(&self) -> &FileMeta;
     async fn read_all(&mut self) -> Result<Vec<u8>, Error>;
@@ -69,7 +69,7 @@ impl RamFile {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl File for RamFile {
     fn meta(&self) -> &FileMeta {
         &self.meta
@@ -81,10 +81,8 @@ impl File for RamFile {
 }
 
 #[async_trait(?Send)]
-pub trait StorageEntity {
-    async fn list_filemetas(&mut self) -> Result<Vec<FileMeta>, Error>;
-    async fn fetch_file(&mut self, meta: &FileMeta) -> Result<Box<dyn File>, Error>;
+pub trait StorageEntity<F: File> {
+    async fn list_files(&mut self) -> Result<Vec<F>, Error>;
     async fn create_file(&mut self, file: &mut impl File) -> Result<(), Error>;
-    async fn remove_file(&mut self, meta: &FileMeta) -> Result<(), Error>;
-    async fn create_dir(&mut self, meta: &FileMeta) -> Result<(), Error>;
+    async fn remove_file(&mut self, file: &F) -> Result<(), Error>;
 }

--- a/src/aqfs.rs
+++ b/src/aqfs.rs
@@ -82,9 +82,9 @@ impl File for RamFile {
 
 #[async_trait(?Send)]
 pub trait StorageEntity {
-    async fn list_filemetas(&self) -> Result<Vec<FileMeta>, Error>;
-    async fn fetch_file(&self, meta: &FileMeta) -> Result<Box<dyn File>, Error>;
-    async fn create_file(&self, file: &mut impl File) -> Result<(), Error>;
-    async fn remove_file(&self, meta: &FileMeta) -> Result<(), Error>;
-    async fn create_dir(&self, meta: &FileMeta) -> Result<(), Error>;
+    async fn list_filemetas(&mut self) -> Result<Vec<FileMeta>, Error>;
+    async fn fetch_file(&mut self, meta: &FileMeta) -> Result<Box<dyn File>, Error>;
+    async fn create_file(&mut self, file: &mut impl File) -> Result<(), Error>;
+    async fn remove_file(&mut self, meta: &FileMeta) -> Result<(), Error>;
+    async fn create_dir(&mut self, meta: &FileMeta) -> Result<(), Error>;
 }

--- a/src/local.rs
+++ b/src/local.rs
@@ -93,8 +93,10 @@ impl aqfs::StorageEntity for Storage {
         Ok(())
     }
 
-    async fn remove_file(&self, _meta: &aqfs::FileMeta) -> Result<(), aqfs::Error> {
-        Err(aqfs::Error::NotImplemented)
+    async fn remove_file(&self, meta: &aqfs::FileMeta) -> Result<(), aqfs::Error> {
+        let realpath = self.get_real_path(&meta.path);
+        std::fs::remove_file(realpath)?;
+        Ok(())
     }
 
     async fn create_dir(&self, _meta: &aqfs::FileMeta) -> Result<(), aqfs::Error> {
@@ -132,6 +134,10 @@ mod test {
         assert_eq!(metas.len(), 1);
         let bytes = storage.fetch_file(&metas[0]).await?.read_all().await?;
         assert_eq!(std::str::from_utf8(&bytes).unwrap(), "dummy content");
+        storage.remove_file(&metas[0]).await?;
+        let metas = storage.list_filemetas().await?;
+        assert_eq!(metas.len(), 0);
+
         Ok(())
     }
 }

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -1,11 +1,12 @@
 use crate::aqfs;
+use crate::aqfs::File as FileTrait;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures;
 use rusoto_core::Region;
-use rusoto_s3::{GetObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Client, S3};
+use rusoto_s3::{GetObjectRequest, ListObjectsV2Request, PutObjectRequest, S3};
 use serde::{Deserialize, Serialize};
-use std::{env, str::FromStr};
+use std::{cell::RefCell, collections::HashMap, env, rc::Rc, str::FromStr};
 use tokio::io::AsyncReadExt;
 use uuid::Uuid;
 
@@ -21,64 +22,17 @@ impl From<bincode::Error> for aqfs::Error {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct File {
-    meta: aqfs::FileMeta,
-    key: String,
-}
-
-#[async_trait]
-impl aqfs::File for File {
-    fn meta(&self) -> &aqfs::FileMeta {
-        &self.meta
-    }
-
-    async fn read_all(&mut self) -> Result<Vec<u8>, aqfs::Error> {
-        Err(aqfs::Error::NotImplemented)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-enum Journal {
-    CreateFile { file: File },
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct JournalRecord {
-    journal: Journal,
-    timestamp: DateTime<Utc>,
-    key: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct JournalFile {
-    records: Vec<JournalRecord>,
-    // FIXME: Add blockchain to detect any branch on the journal.
-}
-
-pub struct Storage {
-    client: S3Client,
+struct S3Client {
+    client: rusoto_s3::S3Client,
     bucket: String,
 }
 
-impl Storage {
+impl S3Client {
     pub fn new(region: Region, bucket: String) -> Self {
-        Storage {
-            client: S3Client::new(region),
+        Self {
+            client: rusoto_s3::S3Client::new(region),
             bucket: bucket,
         }
-    }
-
-    pub fn default() -> Storage {
-        let region = match env::var("S3_REGION") {
-            Ok(s) => Region::from_str(&s).unwrap(),
-            Err(_) => Region::Custom {
-                name: "s3-asynq".to_string(),
-                endpoint: env::var("S3_ENDPOINT").unwrap_or("http://localhost:9000".to_string()),
-            },
-        };
-        let bucket = env::var("S3_BUCKET").unwrap_or("asynq".to_string());
-        Self::new(region, bucket)
     }
 
     async fn get_object(&self, key: String) -> Result<rusoto_s3::GetObjectOutput, aqfs::Error> {
@@ -111,17 +65,88 @@ impl Storage {
     }
 }
 
+pub struct File {
+    client: Rc<RefCell<S3Client>>,
+    meta: aqfs::FileMeta,
+    key: String,
+}
+
 #[async_trait(?Send)]
-impl aqfs::StorageEntity for Storage {
-    async fn list_filemetas(&mut self) -> Result<Vec<aqfs::FileMeta>, aqfs::Error> {
+impl aqfs::File for File {
+    fn meta(&self) -> &aqfs::FileMeta {
+        &self.meta
+    }
+
+    async fn read_all(&mut self) -> Result<Vec<u8>, aqfs::Error> {
+        let mut src = Vec::new();
+        self.client
+            .borrow()
+            .get_object(self.key.clone())
+            .await?
+            .body
+            .unwrap()
+            .into_async_read()
+            .read_to_end(&mut src)
+            .await?;
+        Ok(src)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+enum Journal {
+    CreateFile { meta: aqfs::FileMeta, key: String },
+    RemoveFile { meta: aqfs::FileMeta },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JournalRecord {
+    journal: Journal,
+    timestamp: DateTime<Utc>,
+    key: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JournalFile {
+    records: Vec<JournalRecord>,
+    // FIXME: Add blockchain to detect any branch on the journal.
+}
+
+pub struct Storage {
+    client: Rc<RefCell<S3Client>>,
+}
+
+impl Storage {
+    pub fn new(region: Region, bucket: String) -> Self {
+        Storage {
+            client: Rc::new(RefCell::new(S3Client {
+                client: rusoto_s3::S3Client::new(region),
+                bucket: bucket,
+            })),
+        }
+    }
+
+    pub fn default() -> Storage {
+        let region = match env::var("S3_REGION") {
+            Ok(s) => Region::from_str(&s).unwrap(),
+            Err(_) => Region::Custom {
+                name: "s3-asynq".to_string(),
+                endpoint: env::var("S3_ENDPOINT").unwrap_or("http://localhost:9000".to_string()),
+            },
+        };
+        let bucket = env::var("S3_BUCKET").unwrap_or("asynq".to_string());
+        Self::new(region, bucket)
+    }
+
+    // Fetch and parse journal, and construct whole file system.
+    async fn fetch_remote_filesystem(&mut self) -> Result<HashMap<aqfs::Path, File>, aqfs::Error> {
         // Get list of journal files (objects) from S3.
         let mut journal_objects = self
+            .client
+            .borrow()
             .list_objects_v2("journal/".to_string())
             .await?
             .contents
-            .ok_or(aqfs::Error::RusotoFail(
-                "Failed in ListObjectsV2: Can't read the content".to_string(),
-            ))?;
+            .unwrap_or(vec![]);
         // Sort by its name.
         journal_objects.sort_by_key(|o| o.key.clone().unwrap());
         // Fetch all journal files from S3 in parallel.
@@ -130,7 +155,9 @@ impl aqfs::StorageEntity for Storage {
             .map(|o| async {
                 // Get the object, read it, and parse it into struct JournalFile.
                 let mut src = Vec::new();
-                self.get_object(o.key.unwrap())
+                self.client
+                    .borrow()
+                    .get_object(o.key.unwrap())
                     .await?
                     .body
                     .unwrap()
@@ -141,33 +168,49 @@ impl aqfs::StorageEntity for Storage {
             })
             .collect::<Vec<_>>();
         let journal_files: Vec<JournalFile> = futures::future::try_join_all(futures).await?;
-        // Turn journal files into one journal.
-        let journal = journal_files
+        // Follow the journal and construct whole file system.
+        let mut fs = HashMap::new();
+        for rec in journal_files
             .into_iter()
             .flat_map(|j| j.records.into_iter())
-            .collect::<Vec<_>>();
-        // FIXME: Cache for journal.
-        // FIXME: Follow the journal to get correct current files.
-        let metas = journal
-            .into_iter()
-            .map(|r| match r.journal {
-                Journal::CreateFile { file } => file.meta,
-            })
-            .collect::<Vec<_>>();
-        Ok(metas)
+        {
+            match rec.journal {
+                Journal::CreateFile { meta, key } => {
+                    fs.insert(
+                        meta.path.clone(),
+                        File {
+                            meta,
+                            key,
+                            client: Rc::clone(&self.client),
+                        },
+                    );
+                }
+                Journal::RemoveFile { meta } => {
+                    fs.remove(&meta.path);
+                }
+            }
+        }
+        Ok(fs)
     }
+}
 
-    async fn fetch_file(
-        &mut self,
-        _meta: &aqfs::FileMeta,
-    ) -> Result<Box<dyn aqfs::File>, aqfs::Error> {
-        Err(aqfs::Error::NotImplemented)
+#[async_trait(?Send)]
+impl aqfs::StorageEntity<File> for Storage {
+    async fn list_files(&mut self) -> Result<Vec<File>, aqfs::Error> {
+        Ok(self
+            .fetch_remote_filesystem()
+            .await?
+            .into_iter()
+            .map(|(_, f)| f)
+            .collect())
     }
 
     async fn create_file(&mut self, file: &mut impl aqfs::File) -> Result<(), aqfs::Error> {
         // Upload the file's content.
         let key = format!("data/{}", Uuid::new_v4().to_simple().to_string());
-        self.put_object(key.clone(), Some(file.read_all().await?.into()))
+        self.client
+            .borrow()
+            .put_object(key.clone(), Some(file.read_all().await?.into()))
             .await?;
 
         // Create journal and put it to journal/.
@@ -182,23 +225,39 @@ impl aqfs::StorageEntity for Storage {
             records: vec![JournalRecord {
                 timestamp,
                 key: journal_key.clone(),
-                journal: Journal::CreateFile {
-                    file: File { meta, key },
-                },
+                journal: Journal::CreateFile { meta, key },
             }],
         })?;
-        self.put_object(journal_key, Some(journal.into())).await?;
+        self.client
+            .borrow()
+            .put_object(journal_key, Some(journal.into()))
+            .await?;
         // FIXME: Check if the upload has been done successfully, especially any branch of the journal did not occur.
 
         Ok(())
     }
 
-    async fn remove_file(&mut self, _meta: &aqfs::FileMeta) -> Result<(), aqfs::Error> {
-        Err(aqfs::Error::NotImplemented)
-    }
-
-    async fn create_dir(&mut self, _meta: &aqfs::FileMeta) -> Result<(), aqfs::Error> {
-        Err(aqfs::Error::NotImplemented)
+    async fn remove_file(&mut self, file: &File) -> Result<(), aqfs::Error> {
+        // FIXME: Check if the file exists.
+        let timestamp = Utc::now();
+        let journal_key = format!(
+            "journal/{}-{}",
+            timestamp.format("%Y%m%d%H%M%S%f"),
+            Uuid::new_v4().to_simple().to_string()
+        );
+        let meta = file.meta().clone();
+        let journal = bincode::serialize(&JournalFile {
+            records: vec![JournalRecord {
+                timestamp,
+                key: journal_key.clone(),
+                journal: Journal::RemoveFile { meta },
+            }],
+        })?;
+        self.client
+            .borrow()
+            .put_object(journal_key, Some(journal.into()))
+            .await?;
+        Ok(())
     }
 }
 
@@ -206,6 +265,7 @@ impl aqfs::StorageEntity for Storage {
 mod test {
     use super::*;
     use crate::aqfs::StorageEntity;
+    use chrono::offset::TimeZone;
 
     async fn get_test_storage() -> Storage {
         let region = Region::Custom {
@@ -213,7 +273,7 @@ mod test {
             endpoint: "http://localhost:9000".to_string(),
         };
         let bucket = format!("asynq-test-{}", Uuid::new_v4().to_simple());
-        let client = S3Client::new(region.clone());
+        let client = rusoto_s3::S3Client::new(region.clone());
 
         // create new bucket.
         let mut request = rusoto_s3::CreateBucketRequest::default();
@@ -228,19 +288,25 @@ mod test {
 
     #[tokio::test]
     async fn works() -> Result<(), aqfs::Error> {
-        let mut cloud = get_test_storage().await;
-
-        cloud
+        let mut storage = get_test_storage().await;
+        let files = storage.list_files().await?;
+        assert_eq!(files.len(), 0);
+        storage
             .create_file(&mut aqfs::RamFile::new(
                 aqfs::FileMeta {
                     path: aqfs::Path::new(vec!["dummy-path".to_string()]),
-                    mtime: Utc::now(),
+                    mtime: Utc.timestamp(0, 0),
                 },
                 "dummy content".to_string().into_bytes(),
             ))
             .await?;
-
-        cloud.list_filemetas().await?;
+        let mut files = storage.list_files().await?;
+        assert_eq!(files.len(), 1);
+        let bytes = files[0].read_all().await?;
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "dummy content");
+        storage.remove_file(&files[0]).await?;
+        let files = storage.list_files().await?;
+        assert_eq!(files.len(), 0);
 
         Ok(())
     }


### PR DESCRIPTION
`StorageEntity` で行える操作のうちファイルに関するものを全て実装した。ディレクトリに関するものは方針が決まらないので、とりあえず削除した。実装にあたっていくつか根本的なところが変わっている。
- `list_filemetas` を `list_files` にして、 `Vec<File>` を返すようにした。これに伴って `StorageEntity` は型引数にファイルの型を取るようにした。また `fetch_file` が要らなくなったので消した。
- S3のジャーナルに `RemoveFile` を追加し、 `Storage::fetch_remote_filesystem()` でジャーナルを追っかけてファイルのリストを構成するようにした。
- `rusoto_s3::S3Client` の持ち方を変更して、S3の `File::read_all()` で使えるようにした。