### PR TITLE
Add StorageSyncer to synchronize storages

### DIFF
--- a/src/aqfs.rs
+++ b/src/aqfs.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Error {
@@ -58,6 +59,14 @@ pub trait File {
     async fn read_all(&mut self) -> Result<Vec<u8>, Error>;
 }
 
+#[async_trait(?Send)]
+pub trait StorageEntity<F: File> {
+    async fn list_files(&mut self) -> Result<Vec<F>, Error>;
+    async fn create_file(&mut self, mut file: impl File + 'async_trait) -> Result<(), Error>;
+    async fn remove_file(&mut self, file: &F) -> Result<(), Error>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RamFile {
     meta: FileMeta,
     data: Vec<u8>,
@@ -80,9 +89,68 @@ impl File for RamFile {
     }
 }
 
+pub struct RamStorage {
+    files: HashMap<Path, RamFile>,
+}
+
+impl RamStorage {
+    pub fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+        }
+    }
+}
+
 #[async_trait(?Send)]
-pub trait StorageEntity<F: File> {
-    async fn list_files(&mut self) -> Result<Vec<F>, Error>;
-    async fn create_file(&mut self, file: &mut impl File) -> Result<(), Error>;
-    async fn remove_file(&mut self, file: &F) -> Result<(), Error>;
+impl StorageEntity<RamFile> for RamStorage {
+    async fn list_files(&mut self) -> Result<Vec<RamFile>, Error> {
+        Ok(self
+            .files
+            .iter()
+            .map(|f| f.1.clone())
+            .collect::<Vec<RamFile>>())
+    }
+
+    async fn create_file(&mut self, mut file: impl File + 'async_trait) -> Result<(), Error> {
+        self.files.insert(
+            file.meta().path.clone(),
+            RamFile::new(file.meta().clone(), file.read_all().await?),
+        );
+        Ok(())
+    }
+
+    async fn remove_file(&mut self, file: &RamFile) -> Result<(), Error> {
+        self.files.remove(&file.meta().path);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::offset::TimeZone;
+
+    #[tokio::test]
+    async fn ram_storage_works() -> Result<(), Error> {
+        let mut storage = RamStorage::new();
+        let files = storage.list_files().await?;
+        assert_eq!(files.len(), 0);
+        storage
+            .create_file(RamFile::new(
+                FileMeta {
+                    path: Path::new(vec!["dummy-path".to_string()]),
+                    mtime: Utc.timestamp(0, 0),
+                },
+                "dummy content".to_string().into_bytes(),
+            ))
+            .await?;
+        let mut files = storage.list_files().await?;
+        assert_eq!(files.len(), 1);
+        let bytes = files[0].read_all().await?;
+        assert_eq!(std::str::from_utf8(&bytes).unwrap(), "dummy content");
+        storage.remove_file(&files[0]).await?;
+        let files = storage.list_files().await?;
+        assert_eq!(files.len(), 0);
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod aqfs;
 mod local;
 mod s3;
+mod sync;
 
 #[tokio::main]
 async fn main() {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,107 @@
+use crate::aqfs;
+
+struct StorageSyncer<
+    ST0: aqfs::StorageEntity<F0>,
+    ST1: aqfs::StorageEntity<F1>,
+    F0: aqfs::File,
+    F1: aqfs::File,
+> {
+    st0: ST0,
+    st1: ST1,
+
+    // Thanks to: https://qnighy.hatenablog.com/entry/2018/01/14/220000
+    _marker0: std::marker::PhantomData<fn() -> F0>,
+    _marker1: std::marker::PhantomData<fn() -> F1>,
+}
+
+impl<
+        ST0: aqfs::StorageEntity<F0>,
+        ST1: aqfs::StorageEntity<F1>,
+        F0: aqfs::File,
+        F1: aqfs::File,
+    > StorageSyncer<ST0, ST1, F0, F1>
+{
+    pub fn new(st0: ST0, st1: ST1) -> Self {
+        Self {
+            st0,
+            st1,
+            _marker0: std::marker::PhantomData,
+            _marker1: std::marker::PhantomData,
+        }
+    }
+
+    pub async fn sync(&mut self) -> Result<(), aqfs::Error> {
+        // FIXME: We MUST need MUCH MUCH smarter algorithms here.
+        // Send files from st0 to st1.
+        for f in self.st0.list_files().await?.into_iter() {
+            self.st1.create_file(f).await?;
+        }
+        // Send files from st1 to st0.
+        for f in self.st1.list_files().await?.into_iter() {
+            self.st0.create_file(f).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::aqfs::{File, StorageEntity};
+    use chrono::offset::TimeZone;
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    async fn is_storages_equivalent(
+        st0: &mut aqfs::RamStorage,
+        st1: &mut aqfs::RamStorage,
+    ) -> bool {
+        let st0_files = st0.list_files().await.unwrap();
+        let st1_files = st1.list_files().await.unwrap();
+        let mut files = HashMap::new();
+        for mut f in st0_files.into_iter() {
+            files.insert(f.meta().clone(), f.read_all().await.unwrap());
+        }
+        let files = files;
+        for mut f in st1_files.into_iter() {
+            match files.get(f.meta()) {
+                None => return false,
+                Some(str0) => {
+                    let str1 = f.read_all().await.unwrap();
+                    if *str0 != str1 {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    #[tokio::test]
+    async fn works() -> Result<(), aqfs::Error> {
+        let mut st0 = aqfs::RamStorage::new();
+        st0.create_file(aqfs::RamFile::new(
+            aqfs::FileMeta {
+                path: aqfs::Path::new(vec!["dummy-path0".to_string()]),
+                mtime: Utc.timestamp(0, 0),
+            },
+            "dummy content 0".to_string().into_bytes(),
+        ))
+        .await?;
+        let mut st1 = aqfs::RamStorage::new();
+        st1.create_file(aqfs::RamFile::new(
+            aqfs::FileMeta {
+                path: aqfs::Path::new(vec!["dummy-path1".to_string()]),
+                mtime: Utc.timestamp(0, 0),
+            },
+            "dummy content 1".to_string().into_bytes(),
+        ))
+        .await?;
+        let mut syncer = StorageSyncer::new(st0, st1);
+        syncer.sync().await?;
+        assert_eq!(syncer.st0.list_files().await.unwrap().len(), 2);
+        assert_eq!(syncer.st1.list_files().await.unwrap().len(), 2);
+        assert!(is_storages_equivalent(&mut syncer.st0, &mut syncer.st1).await);
+        Ok(())
+    }
+}


### PR DESCRIPTION
二つの `StorageEntity` を同期させるための `StorageSyncer` を新規ファイル `sync.rs` に追加。本体は `sync()` で、現状は手を抜いて (i) Alice -> Bob へのファイル転送 (ii) Bob -> Alice へのファイル転送 を行うだけの実装になっている。これのテストも同じファイルにあって、 `is_storages_equivalent` でちゃんと同期できたか（i.e., ファイルの中身が同じ）を見ている。

それに伴っていくつか既存のコードも変更。
- 主にテストで使うための `StorageEntity` として `RamStorage` を追加。メモリ上に全ファイル情報を持つ。
- `StorageEntity::create_file()` の引数 `file` を `&mut` から `mut` に変更。あとrustcに怒られるままに `+ 'async_trait` をつけた。